### PR TITLE
Make package installable in non-editable mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='UKDRI CR&T Imperial College London',
     author_email='',
     url='https://github.com/ImperialCollegeLondon/minder_utils',
-    packages=['minder_utils',],
+    package_data={"minder_utils.configurations": ["*.yaml"]},
     long_description=open('README.txt').read(),
     install_requires=["requests",
                         "argparse",


### PR DESCRIPTION
The following changes enable `pip install git+https://github.com/ImperialCollegeLondon/minder_utils`, which simplifies the deployment of the Minder missing data report:
- Remove `packages` and instead rely on autodiscovery to ensure that all modules are included, rather than just top-level files as currently
- Specify `package_data` to ensure that configuration files are included in addition to source code